### PR TITLE
Add an error/exception handler

### DIFF
--- a/CalDAVClient.php
+++ b/CalDAVClient.php
@@ -47,7 +47,7 @@ class CalDAVClient {
         
         $str = "";
         foreach($urls as $url) {
-            $str .= "<d:href>$url</d:href>\n";
+            $str .= "<d:href>{$this->url}/$url</d:href>\n";
         }
         
         curl_setopt($ch, CURLOPT_POSTFIELDS,'        
@@ -74,6 +74,15 @@ class CalDAVClient {
             },
         ];
         
+        $output = curl_exec($ch);
+        $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        
+        if($httpcode != 204) {
+            $this->log->error("Bad response http code", ["code"=>$httpcode, "output"=>$output]);
+            return false;
+        }
+        $this->log->debug($output);
         $xml = $service->parse($output);
         return $xml;
     }
@@ -123,8 +132,9 @@ class CalDAVClient {
         $data = [];
         foreach($service->parse($output) as $event) {
             $data[$event['value']['href']] = trim($event['value']['propstat']['prop']['getetag'], '"');
-            $this->log->debug("etag",[
-                "etag" => $event['value']['href'], "url" => $data[$event['value']['href']]]);;
+            $this->log->debug("etag", [
+                "etag" => $data[$event['value']['href']],
+                "url" => $event['value']['href']]);
         }
         return $data;
     }
@@ -176,7 +186,7 @@ class CalDAVClient {
     }
 
     function updateEvent($url, $etag, $data) {
-        $ch = $this->init_curl_request($this->url . '/' . $url);
+        $ch = $this->init_curl_request("{$this->url}/$url");
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
 
         curl_setopt($ch, CURLOPT_HEADER  , true);
@@ -193,8 +203,8 @@ class CalDAVClient {
         curl_close($ch);
         
         if($httpcode != 204) {
-            $this->log->error("Bad response http code", ["code"=>$httpcode, "output"=>$output]);
-            return NULL;
+            $this->log->error("Bad response http code for $url with ETag $etag", ["code"=>$httpcode, "output"=>$output]);
+            return false;
         }
         
         $output = rtrim($output);

--- a/CalDAVClient.php
+++ b/CalDAVClient.php
@@ -78,7 +78,7 @@ class CalDAVClient {
         $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
         
-        if($httpcode != 204) {
+        if($httpcode != 207) {
             $this->log->error("Bad response http code", ["code"=>$httpcode, "output"=>$output]);
             return false;
         }

--- a/agenda.php
+++ b/agenda.php
@@ -119,7 +119,7 @@ class Agenda {
             $events[$eventName] = $vcal;
         }    
         uasort($events, function ($v1, $v2) {
-            return $v1->VEVENT->DTSTART->getDateTime() > $v2->VEVENT->DTSTART->getDateTime();
+            return $v1->VEVENT->DTSTART->getDateTime()->getTimestamp() - $v2->VEVENT->DTSTART->getDateTime()->getTimestamp();
         });
         
         return $events;
@@ -193,7 +193,6 @@ class Agenda {
                 
                 $this->localcache->deleteEvent($eventName);
                 
-                
                 // parse event to get its DTSTART
                 $vcal = \Sabre\VObject\Reader::read($event['value']['propstat']['prop']['{urn:ietf:params:xml:ns:caldav}calendar-data']);
                 $startDate = $vcal->VEVENT->DTSTART->getDateTime();
@@ -220,7 +219,7 @@ class Agenda {
                 foreach($vcal->VEVENT->ATTENDEE as $attendee) {
                     if(str_replace("mailto:","", (string)$attendee) === $usermail) {
                         $this->log->info("Try to add a already registered attendee");
-                        return;
+                        return true; // not an error
                     }
                 }
             }
@@ -249,7 +248,7 @@ class Agenda {
             
             if($already_out) {
                 $this->log->info("Try to remove an unregistered email");
-                return;
+                return true; // not an error
             }
         }
         
@@ -258,10 +257,13 @@ class Agenda {
         $this->log->debug($vcal->serialize());
         if(is_null($new_etag)) {
             $this->log->info("The server did not answer a new etag after an event update, need to update the local calendar");
-            $this->updateEvents(array($url));
+            if(!$this->updateEvents(array($url))) {
+                return false;
+            }
         } else {
             $this->localcache->addEvent($url, $vcal->serialize(), $new_etag);
         }
+        return true;
     }
 
     function getEvent($url) {

--- a/agenda.php
+++ b/agenda.php
@@ -144,18 +144,16 @@ class Agenda {
     protected function updateInternalState($etags) {
         $url_to_update = [];
         foreach($etags as $url => $remote_etag) {
-            $tmp = explode("/", $url);
-            $eventName = end($tmp);
+            $eventName = basename($url);
             if($this->localcache->eventExists($eventName)) {
                 $local_etag = $this->localcache->getEventEtag($eventName);
-                $this->log->debug(end($tmp), ["remote_etag"=>$remote_etag, "local_etag" => $local_etag]);
+                $this->log->debug($eventName, ["remote_etag"=>$remote_etag, "local_etag" => $local_etag]);
                 
-                if($local_etag != $remote_etag) {
-                    // local and remote etag differs, need update
-                    $url_to_update[] = $url;
+                if($local_etag != $remote_etag) { // local and remote etag differs, need update
+                    $url_to_update[] = $eventName;
                 }
             } else {
-                $url_to_update[] = $url;
+                $url_to_update[] = $eventName;
             }
         }
         

--- a/config.json.sample
+++ b/config.json.sample
@@ -1,0 +1,3 @@
+{
+    "error_message" : "Error, please contact your administrator."
+}

--- a/index.php
+++ b/index.php
@@ -41,8 +41,10 @@ if(is_null($credentials)) {
     exit();
 }
 
-if(!property_exists($credentials, 'signing_secret') || !property_exists($credentials, 'slack_bot_token')) {
-    $log->error('signing_secret and/or slack_bot_token not present in credentials.json');
+if(!property_exists($credentials, 'signing_secret') ||
+   !property_exists($credentials, 'slack_bot_token') ||
+   !property_exists($credentials, 'slack_user_token')) {
+    $log->error('signing_secret and/or Slack tokens not stored in credentials.json');
     exit();
 }
 
@@ -107,7 +109,7 @@ if(property_exists($json, 'type') and
     exit();
 }
 
-$api = new SlackAPI($credentials->slack_bot_token, $log);
+$api = new SlackAPI($credentials->slack_bot_token, $credentials->slack_user_token, $log);
 $agenda = new Agenda($credentials->caldav_url, $credentials->caldav_username, $credentials->caldav_password, new FilesystemCache("./data"));
 $slack_events = new SlackEvents($agenda, $api, $log);
 

--- a/slackAPI.php
+++ b/slackAPI.php
@@ -84,7 +84,7 @@ class SlackAPI{
         curl_setopt($ch, CURLOPT_POSTFIELDS, array(
             "token" => $this->slack_user_token
         ));
-        return json_decode($this->curl_process($ch));
+        return json_decode($this->curl_process($ch), true);
     }
 
     function reminders_delete($reminder_id) {


### PR DESCRIPTION
- errors are transformed as exceptions (thus the same function can handle both errors and exceptions). I discovered that: `1/0` triggers an exception (division by 0), and `$a=$b*4;` triggers an error (Undefined variable)...
- errors/exceptions are handled by `exception_handler()`;
- the content of the Slack app is replaced by a message that can be configured in `config.json`.

I have used `set_exception_handler()` and `set_error_handler()` instead of `register_shutdown_function()` because:
- the handler is called if, and only if there is an error/exception, rather than being called at each shutdown;
- `register_shutdown_function()` may fails when handling relative paths (https://stackoverflow.com/questions/13924465/shutdown-handlers-and-relative-paths).

Tell me what you think about these changes :)