### PR TITLE
Decline invitation directly from the CalDAV server

### DIFF
--- a/agenda.php
+++ b/agenda.php
@@ -215,7 +215,7 @@ class Agenda {
         $etag = $this->localcache->getEventEtag($url);
         
         $vcal = \Sabre\VObject\Reader::read($raw);
-        $this->log->debug("attendee", [$vcal->VEVENT->ATTENDEE]);
+        
         if($add) {
             if(isset($vcal->VEVENT->ATTENDEE)) {
                 foreach($vcal->VEVENT->ATTENDEE as $attendee) {

--- a/agenda.php
+++ b/agenda.php
@@ -36,6 +36,10 @@ class Agenda {
             
             if(isset($event->VEVENT->ATTENDEE)) {
                 foreach($event->VEVENT->ATTENDEE as $attendee) {
+                    if(isset($attendee['PARTSTAT']) and (string)$attendee['PARTSTAT'] === "DECLINED") {
+                        $this->log->debug("user $attendee has declined event outside the app.");
+                        continue;
+                    }
                     $a = [
                         //"cn" => $attendee['CN']->getValue(),
                         "mail" => str_replace("mailto:", "", (string)$attendee)
@@ -211,26 +215,33 @@ class Agenda {
         $etag = $this->localcache->getEventEtag($url);
         
         $vcal = \Sabre\VObject\Reader::read($raw);
-        
+        $this->log->debug("attendee", [$vcal->VEVENT->ATTENDEE]);
         if($add) {
             if(isset($vcal->VEVENT->ATTENDEE)) {
                 foreach($vcal->VEVENT->ATTENDEE as $attendee) {
                     if(str_replace("mailto:","", (string)$attendee) === $usermail) {
-                        $this->log->info("Try to add a already registered attendee");
-                        return true; // not an error
+                        if(isset($attendee['PARTSTAT']) && (string)$attendee['PARTSTAT'] === "DECLINED") {
+                            $this->log->info("Try to add a user that have already declined invitation (from outside).");
+                            // clean up
+                            $vcal->VEVENT->remove($attendee);
+                            // will add again the user
+                            break;
+                        } else {
+                            $this->log->info("Try to add a already registered attendee");
+                            return true; // not an error
+                        }
                     }
                 }
             }
             
-            /*$vcal->VEVENT->add(
-              'ATTENDEE',
-              'mailto:' . $usermail,
-              [
-              'RSVP' => 'TRUE',
-              'CN'   => (is_null($attendee_CN)) ? 'Bénévole' : $attendee_CN, //@TODO
-              ]
-              );*/
-            $vcal->VEVENT->add('ATTENDEE', 'mailto:' . $usermail);
+            $vcal->VEVENT->add(
+                'ATTENDEE',
+                'mailto:' . $usermail,
+                [
+                    'CN'   => (is_null($attendee_CN)) ? 'Bénévole' : $attendee_CN,
+                ]
+            );
+            //$vcal->VEVENT->add('ATTENDEE', 'mailto:' . $usermail);
         } else {
             $already_out = true;
             


### PR DESCRIPTION
Users will receive emails when they register for an event. 
It is possible to decline afterwards the invitation by following a link on this email. Attendees are then tagged with `PARTSTAT=DECLINED`, but are not deleted.
This PR handle that situation.