### PR TITLE
Increase log severity on failed query to slack

### DIFF
--- a/slackAPI.php
+++ b/slackAPI.php
@@ -58,8 +58,8 @@ class SlackAPI{
             if(!is_null($error) and isset(slackAPI::QUIET_ERRORS[$function]) and in_array($error, slackAPI::QUIET_ERRORS[$function])) {
                 // nothing to do
             } else {
-                $this->log->info("API call failed in {$trace[1]["function"]}.");
-                $this->log->info("raw response: $response");
+                $this->log->error("API call failed in {$trace[1]["function"]}.");
+                $this->log->error("raw response: $response");
             }
             
             return NULL;


### PR DESCRIPTION
I decreased it a couple days ago to avoid the noise due to false
positive, but since those false positive are now filtered out, we can
log errors as error again