### PR TITLE
Fix reminder date

### DIFF
--- a/slackEvents.php
+++ b/slackEvents.php
@@ -285,7 +285,7 @@ class SlackEvents {
 
         $vevent = $this->agenda->getEvent($url)->VEVENT;
         $datetime = $vevent->DTSTART->getDateTime();
-        $datetime->modify("-1 day");
+        $datetime = $datetime->modify("-1 day");
         
         if($in) {
             $summary = (string)$vevent->SUMMARY;


### PR DESCRIPTION
Reminders are currently created at the date of the event, not 1 day before.
That's because we manipulate DateTimeImmutable (and not DateTime) so we need
to retrieve the result of the call to "modify"