### PR TITLE
Add logging to troubleshoot #40

### DIFF
--- a/localcache.php
+++ b/localcache.php
@@ -47,8 +47,10 @@ class FilesystemCache implements Localcache {
     function getSerializedEvent($eventName) {
         if(is_file($this->root . $eventName)) {
             return file_get_contents_safe($this->root . $eventName);
+        } else {
+          $this->log->debug("Can't get event $eventName: it is not present in local cache");
+          return null;
         }
-        return null;
     }
     
     function getctag(){


### PR DESCRIPTION
I suspect that this issue is caused by this method returning NULL. This commit
will make it possible to test this hypothesis. With this additional info it will
be more convenient to understand where such inconsistent state may come from.