### PR TITLE
Agenda class: from interface to abstract class

### DIFF
--- a/FSAgenda.php
+++ b/FSAgenda.php
@@ -3,10 +3,8 @@
 use Monolog\Logger;
 use Sabre\VObject;
 
-class FSAgenda implements Agenda {
-    private $caldav_client;
+class FSAgenda extends Agenda {
     protected $localcache;
-    protected $api;
     
     public function __construct(string $vCalendarFilename, string $username, string $password, object $api, array $agenda_args) {
         $this->log = new Logger('Agenda');
@@ -23,8 +21,8 @@ class FSAgenda implements Agenda {
         $parsed_events = array();
         
         foreach($this->localcache->getAllEventsFilenames() as $vCalendarFilename) {
-            $event = $this->getEvent($vCalendarFilename);
-            $parsed_event = $this->parseEvent($userid, $event);
+            list($vCalendar, $ETag) = $this->getEvent($vCalendarFilename);
+            $parsed_event = $this->parseEvent($userid, $vCalendar);
 
             $parsed_event["keep"] = true;
             
@@ -102,7 +100,11 @@ class FSAgenda implements Agenda {
         }
         return $parsed_event;
     }
-
+    
+    public function getParsedEvent(string $vCalendarFilename, string $userid) {
+        list($vCalendar, $ETag) = $this->getEvent($vCalendarFilename);
+        return $this->parseEvent($userid, $vCalendar);
+    }
 
     public function getEvents() {
         $events = array();
@@ -122,34 +124,9 @@ class FSAgenda implements Agenda {
         
         return $events;
     }
-    
-    // update agenda
-    public function update() {
-        $remote_CTag = $this->caldav_client->getCTag();
-        if(is_null($remote_CTag)) {
-            $this->log->error("Fail to update the CTag");
-            return;
-        }
-        
-        // check if we need to update events from the server
-        $local_CTag = $this->localcache->getCTag();
-        $this->log->debug("local CTag is $local_CTag, remote CTag is $remote_CTag");
-        if (is_null($local_CTag) || $local_CTag != $remote_CTag){
-            $this->log->debug("Agenda update needed");
-            
-            $remote_ETags = $this->caldav_client->getETags();
-            if($remote_CTag === false || is_null($remote_CTag)) {
-                $this->log->error("Fail to get calendar ETags");
-                return;
-            }
-            
-            $this->updateInternalState($remote_ETags);
-            $this->localcache->setCTag($remote_CTag);
-        }
-    }
 
     // 
-    protected function updateInternalState(array $ETags) {
+    protected function update(array $ETags) {
         $vCalendarFilename_to_update = [];
         foreach($ETags as $vCalendarFilename => $remote_ETag) {
             $vCalendarFilename = basename($vCalendarFilename);
@@ -175,6 +152,14 @@ class FSAgenda implements Agenda {
         $this->removeDeletedEvents($ETags);
     }
     
+    protected function getCTag() {
+        return $this->localcache->getCTag();
+    }
+
+    protected function setCTag(string $CTag) {
+        $this->localcache->setCTag($CTag);
+    }
+    
     // delete local events that have been deleted on the server
     protected function removeDeletedEvents(array $ETags) {
         $vCalendarFilenames = [];
@@ -192,109 +177,35 @@ class FSAgenda implements Agenda {
         }
     }
 
-    private function updateEvents(array $vCalendarFilenames) {
-        $events = $this->caldav_client->updateEvents($vCalendarFilenames);
+    protected function updateEvent(array $event) {
+        $this->localcache->deleteEvent($event['vCalendarFilename']);
         
-        if(is_null($events) || $events === false) {
-            $this->log->error("Fail to update events ");
-            return false;
-        }
+        // parse event to get its DTSTART
+        $vCalendar = \Sabre\VObject\Reader::read($event['vCalendarRaw']);
+        $startDate = $vCalendar->VEVENT->DTSTART->getDateTime();
+	    
+        if($startDate < new DateTime('NOW')) {
+            $this->log->debug("Event is in the past, skiping");
+            return;
 
-        foreach($events as $event) {
-            $this->log->info("Adding event $event[vCalendarFilename]");
-            
-            $this->localcache->deleteEvent($event['vCalendarFilename']);
-            
-            // parse event to get its DTSTART
-            $vCalendar = \Sabre\VObject\Reader::read($event['vCalendarRaw']);
-            $startDate = $vCalendar->VEVENT->DTSTART->getDateTime();
-            
-            if($startDate < new DateTime('NOW')) {
-                $this->log->debug("Event is in the past, skiping");
-                continue;
-            }
-            
-            $this->localcache->addEvent(
-                $event['vCalendarFilename'],
-                $event['vCalendarRaw'],
-                $event['ETag']
-            );
         }
-        return true;
+	    
+        $this->localcache->addEvent(
+            $event['vCalendarFilename'],
+            $event['vCalendarRaw'],
+            $event['ETag']
+        );
     }
-    
-    //if add is true, then add $usermail to the event, otherwise, remove it.
-    public function updateAttendee(string $vCalendarFilename, string $usermail, bool $add, ?string $attendee_CN=null) {
-        $this->log->info("updating $vCalendarFilename");
-        $vCalendarRaw = $this->localcache->getSerializedEvent($vCalendarFilename);
-        $ETag = $this->localcache->getEventETag($vCalendarFilename);
-        
-        $vCalendar = \Sabre\VObject\Reader::read($vCalendarRaw);
-        
-        if($add) {
-            if(isset($vCalendar->VEVENT->ATTENDEE)) {
-                foreach($vCalendar->VEVENT->ATTENDEE as $attendee) {
-                    if(str_replace("mailto:","", (string)$attendee) === $usermail) {
-                        if(isset($attendee['PARTSTAT']) && (string)$attendee['PARTSTAT'] === "DECLINED") {
-                            $this->log->info("Try to add a user that have already declined invitation (from outside).");
-                            // clean up
-                            $vCalendar->VEVENT->remove($attendee);
-                            // will add again the user
-                            break;
-                        } else {
-                            $this->log->info("Try to add a already registered attendee");
-                            return true; // not an error
-                        }
-                    }
-                }
-            }
-            
-            $vCalendar->VEVENT->add(
-                'ATTENDEE',
-                'mailto:' . $usermail,
-                [
-                    'CN'   => (is_null($attendee_CN)) ? 'Bénévole' : $attendee_CN,
-                ]
-            );
-            //$vCalendar->VEVENT->add('ATTENDEE', 'mailto:' . $usermail);
-        } else {
-            $already_out = true;
-            
-            if(isset($vCalendar->VEVENT->ATTENDEE)) {
-                foreach($vCalendar->VEVENT->ATTENDEE as $attendee) {
-                    if(str_replace("mailto:","", (string)$attendee) === $usermail) {
-                        $vCalendar->VEVENT->remove($attendee);
-                        $already_out = false;
-                        break;
-                    }
-                }
-            }
-            
-            if($already_out) {
-                $this->log->info("Try to remove an unregistered email");
-                return true; // not an error
-            }
-        }
-        
-        $new_ETag = $this->caldav_client->updateEvent($vCalendarFilename, $ETag, $vCalendar->serialize());
-        if($new_ETag === false) {
-            $this->log->error("Fails to update the event");
-            return false;
-        } else if(is_null($new_ETag)) {
-            $this->log->info("The server did not answer a new ETag after an event update, need to update the local calendar");
-            if(!$this->updateEvents(array($vCalendarFilename))) {
-                return false;
-            }
-        } else {
-            $this->localcache->addEvent($vCalendarFilename, $vCalendar->serialize(), $new_ETag);
-        }
-        return true;
+
+    protected function saveEvent(string $url, string $ETag, object $vcal) {
+        return $this->localcache->addEvent($url, $vcal->serialize(), $new_etag);
     }
 
     public function getEvent(string $vCalendarFilename) {
         $vCalendarRaw = $this->localcache->getSerializedEvent($vCalendarFilename);
+        $ETag = $this->localcache->getEventEtag($vCalendarFilename);
         if(!is_null($vCalendarRaw)) {
-            return \Sabre\VObject\Reader::read($vCalendarRaw);
+            return [\Sabre\VObject\Reader::read($vCalendarRaw), $ETag];
         }
     	return null;
     }

--- a/agenda.php
+++ b/agenda.php
@@ -9,15 +9,126 @@ class NotImplementedException extends BadMethodCallException {}
 
 require __DIR__ . '/vendor/autoload.php';
 
-interface Agenda {
-    public function __construct(string $url, string $username, string $password, object $api, array $agenda_args);
-    public function getUserEventsFiltered(string $userid, array $filters_to_apply = array());
-    public function parseEvent(string $userid, object $event);
-    public function getEvents();
-    public function update();
-    public function updateAttendee(string $url, string $usermail, bool $add, ?string $attendee_CN=null);
-    public function getEvent(string $url);
-    public function clearEvents();
+abstract class Agenda {
+    protected $caldav_client;
+    protected $api;
+
+    abstract public function __construct(string $vCalendarFilename, string $username, string $password, object $api, array $agenda_args);
+    abstract public function getUserEventsFiltered(string $userid, array $filters_to_apply = array());
+    abstract public function getParsedEvent(string $vCalendarFilename, string $userid);
+    abstract public function getEvents();
+    abstract protected function update(array $ETags);
+    
+    abstract protected function saveEvent(string $vCalendarFilename, string $ETag, object $vCalendar);
+    abstract protected function getEvent(string $vCalendarFilename);
+    abstract public function clearEvents();
+
+    abstract protected function getCTag();
+    abstract protected function setCTag(string $CTag);
+    
+    public function checkAgenda() {
+        $remote_CTag = $this->caldav_client->getCTag();
+        if(is_null($remote_CTag)) {
+            $this->log->error("Fail to update the CTag");
+            return;
+        }
+        
+        // check if we need to update events from the server
+        $local_CTag = $this->getCTag();
+        $this->log->debug("local CTag is $local_CTag, remote CTag is $remote_CTag");
+        if (is_null($local_CTag) || $local_CTag != $remote_CTag){
+            $this->log->debug("Agenda update needed");
+            
+            $remote_ETags = $this->caldav_client->getETags();
+            if($remote_CTag === false || is_null($remote_CTag)) {
+                $this->log->error("Fail to get calendar ETags");
+                return;
+            }
+            
+            $this->update($remote_ETags);
+            $this->setCTag($remote_CTag);
+        }
+
+    }
+    
+    public function updateAttendee(string $vCalendarFilename, string $usermail, bool $add, ?string $attendee_CN) {
+        $this->log->info("updating $vCalendarFilename");
+        list($vCalendar, $ETag) = $this->getEvent($vCalendarFilename);
+        
+        if($add) {
+            if(isset($vCalendar->VEVENT->ATTENDEE)) {
+                foreach($vCalendar->VEVENT->ATTENDEE as $attendee) {
+                    if(str_replace("mailto:","", (string)$attendee) === $usermail) {
+                        if(isset($attendee['PARTSTAT']) && (string)$attendee['PARTSTAT'] === "DECLINED") {
+                            $this->log->info("Try to add a user that have already declined invitation (from outside).");
+                            // clean up
+                            $vCalendar->VEVENT->remove($attendee);
+                            // will add again the user
+                            break;
+                        } else {
+                            $this->log->info("Try to add a already registered attendee");
+                            return 0; // not an error
+                        }
+                    }
+                }
+            }
+            
+            $vCalendar->VEVENT->add(
+                'ATTENDEE',
+                'mailto:' . $usermail,
+                [
+                    'CN'   => (is_null($attendee_CN)) ? 'Bénévole' : $attendee_CN,
+                ]
+            );
+            //$vCalendar->VEVENT->add('ATTENDEE', 'mailto:' . $usermail);
+        } else {
+            $already_out = true;
+            
+            if(isset($vCalendar->VEVENT->ATTENDEE)) {
+                foreach($vCalendar->VEVENT->ATTENDEE as $attendee) {
+                    if(str_replace("mailto:","", (string)$attendee) === $usermail) {
+                        $vCalendar->VEVENT->remove($attendee);
+                        $already_out = false;
+                        break;
+                    }
+                }
+            }
+            
+            if($already_out) {
+                $this->log->info("Try to remove an unregistered email");
+                return 0; // not an error
+            }
+        }
+        
+        $new_ETag = $this->caldav_client->updateEvent($vCalendarFilename, $ETag, $vCalendar->serialize());
+        if($new_ETag === false) {
+            $this->log->error("Fails to update the event");
+            return false;
+        } else if(is_null($new_ETag)) {
+            $this->log->info("The server did not answer a new ETag after an event update, need to update the local calendar");
+            if(!$this->updateEvents(array($vCalendarFilename))) {
+                return false;
+            }
+        } else {
+            $this->saveEvent($vCalendarFilename, $new_ETag, $vCalendar->serialize());
+        }
+        return true;
+    }
+    
+    protected function updateEvents(array $vCalendarFilenames) {
+        $events = $this->caldav_client->updateEvents($vCalendarFilenames);
+        
+        if(is_null($events) || $events === false) {
+            $this->log->error("Fail to update events ");
+            return false;
+        }
+
+        foreach($events as $event) {
+            $this->log->info("Adding event $event[vCalendarFilename]");
+            $this->updateEvent($event);
+        }
+        return true;
+    }
 }
 
 require_once "FSAgenda.php";

--- a/agenda.php
+++ b/agenda.php
@@ -18,6 +18,7 @@ abstract class Agenda {
     abstract public function getParsedEvent(string $vCalendarFilename, string $userid);
     abstract public function getEvents();
     abstract protected function update(array $ETags);
+    abstract protected function updateEvent(array $event);
     
     abstract protected function saveEvent(string $vCalendarFilename, string $ETag, object $vCalendar);
     abstract protected function getEvent(string $vCalendarFilename);

--- a/agenda.php
+++ b/agenda.php
@@ -42,7 +42,7 @@ abstract class Agenda {
             
             $remote_ETags = $this->caldav_client->getETags();
             if($remote_CTag === false || is_null($remote_CTag)) {
-                $this->log->error("Fail to get calendar ETags");
+                $this->log->error("Fail to get CTag from the remote server");
                 return;
             }
             

--- a/events.php
+++ b/events.php
@@ -25,7 +25,7 @@ $log->info('event: ' . $event_type);
 // @see: https://api.slack.com/events/app_home_opened    
 if($event_type == "app_home_opened") {
     $slack_events->app_home_page($json->event->user);
-    if($agenda->update()) {
+    if($agenda->checkAgenda()) {
         $slack_events->app_home_page($json->event->user);
     }
 }

--- a/slackEvents.php
+++ b/slackEvents.php
@@ -198,9 +198,8 @@ class SlackEvents {
     }
     
     function more($vCalendarFilename, $request) {
-        $vCalendar = $this->agenda->getEvent($vCalendarFilename);
         $userid = $request->user->id;
-        $parsed_event = $this->agenda->parseEvent($userid, $vCalendar);
+        $parsed_event = $this->agenda->getParsedEvent($vCalendarFilename, $userid);
         $trigger_id = $request->trigger_id;
         
         $block = $this->render_event($parsed_event, true);
@@ -267,7 +266,7 @@ class SlackEvents {
         }
         $profile = $user->profile;
         $this->log->debug("register mail $profile->email $profile->first_name $profile->last_name");
-        $parsed_event = $this->agenda->parseEvent($userid, $this->agenda->getEvent($vCalendarFilename));
+        $parsed_event = $this->agenda->getParsedEvent($vCalendarFilename, $userid);
         slackEvents::ack();
         $this->register_fast_rendering($vCalendarFilename, $userid, $profile->email, $in, $request, $parsed_event);
         
@@ -277,12 +276,12 @@ class SlackEvents {
             $this->app_home_page($userid);
         }
 
-        $vevent = $this->agenda->getEvent($vCalendarFilename)->VEVENT;
-        $datetime = $vevent->DTSTART->getDateTime();
+        $vCalendar = $parsed_event['vCalendar']->VEVENT;
+        $datetime = $vCalendar->DTSTART->getDateTime();
         $datetime = $datetime->modify("-1 day");
         
         if($in) {
-            $summary = (string)$vevent->SUMMARY;
+            $summary = (string)$vCalendar->SUMMARY;
             $now = new DateTimeImmutable();
             if ($datetime < $now){
                 $this->log->debug("not creating the reminder for $userid because " . $datetime->format('Y-m-dTH:i:s') . " is in the past");


### PR DESCRIPTION
Agenda is now an abstract class, instead of an interface.
It will prevent code duplication (as discussed in #39), between backend implementations.