### PR TITLE
close CalDavClient's curl handle when we don't need it

### DIFF
--- a/CalDAVClient.php
+++ b/CalDAVClient.php
@@ -35,27 +35,29 @@ class CalDAVClient {
     }
 
     private function process_curl_request($ch) {
-        $response = curl_exec($ch);
-        
-        if (curl_errno($ch)) {
-            $this->log->error(curl_error($ch) . " (error code " . curl_errno($ch) . ")");
-            return false;
-        }
-        
-        $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        
-        if($httpcode !== 200 && $httpcode !== 204 && $httpcode !== 207) {
-            $url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
-            $this->log->error("Bad HTTP response code: $httpcode for $url");
-            $trace = debug_backtrace();
-            $this->log->error("in ({$trace[1]["function"]}).");
-            $this->log->error($response);
+        try {
+            $response = curl_exec($ch);
+
+            if (curl_errno($ch)) {
+                $this->log->error(curl_error($ch) . " (error code " . curl_errno($ch) . ")");
+                return false;
+            }
+
+            $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+            if($httpcode !== 200 && $httpcode !== 204 && $httpcode !== 207) {
+                $url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+                $this->log->error("Bad HTTP response code: $httpcode for $url");
+                $trace = debug_backtrace();
+                $this->log->error("in ({$trace[1]["function"]}).");
+                $this->log->error($response);
+                return false;
+            }
+
+            return $response;
+        } finally {
             curl_close($ch);
-            return false;
         }
-        curl_close($ch);
-        
-        return $response;
     }
     
     // url that need to be updated

--- a/CalDAVClient.php
+++ b/CalDAVClient.php
@@ -43,7 +43,6 @@ class CalDAVClient {
         }
         
         $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
         
         if($httpcode !== 200 && $httpcode !== 204 && $httpcode !== 207) {
             $url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
@@ -51,8 +50,10 @@ class CalDAVClient {
             $trace = debug_backtrace();
             $this->log->error("in ({$trace[1]["function"]}).");
             $this->log->error($response);
+            curl_close($ch);
             return false;
         }
+        curl_close($ch);
         
         return $response;
     }


### PR DESCRIPTION
Otherwise when we get in the "if($httpcode !== 200 ...)" then the call
to curl_getinfo fails with error

    curl_getinfo(): supplied resource is not a valid cURL handle resource