### PR TITLE
Rm unused parameter $log in SlackAPI constructor

### DIFF
--- a/actions.php
+++ b/actions.php
@@ -21,7 +21,7 @@ if(!property_exists($json, 'actions')) {
 
 $GLOBALS['userid'] = $json->user->id; // in case we need to show an error message to the user
 
-$api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token'], $log);
+$api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
 $agenda = initAgendaFromType($caldav_credentials['url'], $caldav_credentials['username'], $caldav_credentials['password'],
                              $api, $agenda_args, $log);
 $slack_events = new SlackEvents($agenda, $api, $log);

--- a/commands.php
+++ b/commands.php
@@ -13,7 +13,7 @@ if(!isset($_POST['command'])) {
 }
 $command = $_POST['command'];
 
-$api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token'], $log);
+$api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
 $agenda = initAgendaFromType($caldav_credentials['url'], $caldav_credentials['username'], $caldav_credentials['password'],
                              $api, $agenda_args, $log);
 $slack_events = new SlackEvents($agenda, $api, $log);

--- a/events.php
+++ b/events.php
@@ -13,7 +13,7 @@ if(!property_exists($json, 'event') || !property_exists($json->event, 'type')) {
     exit();
 }
 
-$api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token'], $log);
+$api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
 $agenda = initAgendaFromType($caldav_credentials['url'], $caldav_credentials['username'], $caldav_credentials['password'],
                              $api, $agenda_args, $log);
 $slack_events = new SlackEvents($agenda, $api, $log);

--- a/slackAPI.php
+++ b/slackAPI.php
@@ -11,7 +11,7 @@ class SlackAPI{
         "users_lookupByEmail" => array("users_not_found")
     );
     
-    function __construct($slack_bot_token, $slack_user_token, $log) {
+    function __construct($slack_bot_token, $slack_user_token) {
         $this->slack_bot_token = $slack_bot_token;
         $this->slack_user_token = $slack_user_token;
         

--- a/utils.php
+++ b/utils.php
@@ -237,7 +237,7 @@ function exception_handler($throwable) {
         exit();
     }
     
-    $api = new SlackAPI($config->slack_bot_token, $config->slack_user_token, $log);
+    $api = new SlackAPI($config->slack_bot_token, $config->slack_user_token);
     
     $data = [
         'user_id' => $GLOBALS['userid'],


### PR DESCRIPTION
This parameter is not used because we instantiate another Logger in
the constructor