### PR TITLE
Don't DROP DATABASE

### DIFF
--- a/MySQLAgenda.php
+++ b/MySQLAgenda.php
@@ -24,8 +24,6 @@ class MySQLAgenda extends DBAgenda {
     }
     
     public function createDB() {
-        $this->pdo->query("DROP DATABASE IF EXISTS {$this->db_name};");
-        $this->pdo->query("CREATE DATABASE {$this->db_name};");
         $this->pdo->query("USE {$this->db_name};");
         
         $this->pdo->query("CREATE TABLE IF NOT EXISTS events ( 


### PR DESCRIPTION
I'm thinking that it will likely be convenient to store the tables of
this app in an existing db (to benefit from the existing backup scripts
have and because I think we're limited in the number of db we can have
with our hosting plan), so it would be not so cool to drop the whole
database inadvertently.