### PR TITLE
Proposition of a minor refacto: construct Agenda with all the data it needs

### DIFF
--- a/MySQLAgenda.php
+++ b/MySQLAgenda.php
@@ -10,13 +10,11 @@ class MySQLAgenda extends Agenda {
     private $password;
     
     public function __construct(string $CalDAV_url, string $CalDAV_username, string $CalDAV_password, object $api, array $agenda_args) {
-            $this->log = new Logger('MySQLAgenda');
             $this->db_name = $agenda_args["db_name"];
             $this->host = $agenda_args["db_host"];
             $this->username = $agenda_args["db_username"];
             $this->password = $agenda_args["db_password"];
-            $this->table_prefix = $agenda_args["db_table_prefix"];
-            parent::__construct($CalDAV_url, $CalDAV_username, $CalDAV_password, $api);
+            parent::__construct($agenda_args["db_table_prefix"], new Logger('MySQLAgenda'), $CalDAV_url, $CalDAV_username, $CalDAV_password, $api);
         }
     
     protected function openDB() {

--- a/SqliteAgenda.php
+++ b/SqliteAgenda.php
@@ -7,10 +7,8 @@ class SqliteAgenda extends Agenda {
     private $path;
 
     public function __construct(string $CalDAV_url, string $CalDAV_username, string $CalDAV_password, object $api, array $agenda_args) {
-        $this->log = new Logger('sqliteAgenda');
         $this->path = $agenda_args["path"];
-        $this->table_prefix = $agenda_args["db_table_prefix"];
-        parent::__construct($CalDAV_url, $CalDAV_username, $CalDAV_password, $api);
+        parent::__construct($agenda_args["db_table_prefix"], new Logger('sqliteAgenda'), $CalDAV_url, $CalDAV_username, $CalDAV_password, $api);
     }
     
     protected function openDB() {

--- a/agenda.php
+++ b/agenda.php
@@ -16,7 +16,9 @@ abstract class Agenda {
 
     protected $table_prefix;
 
-    public function __construct(string $CalDAV_url, string $CalDAV_username, string $CalDAV_password, object $api) {
+    public function __construct(string $table_prefix, Logger $log, string $CalDAV_url, string $CalDAV_username, string $CalDAV_password, object $api) {
+        $this->table_prefix = $table_prefix;
+        $this->log = $log;
         setLogHandlers($this->log);
         
         $this->caldav_client = new CalDAVClient($CalDAV_url, $CalDAV_username, $CalDAV_password);


### PR DESCRIPTION
with this refacto it's easier to:
- reason about the Agenda class because we don't have to look at its children
  classes anymore to see where its fields are instantiated
- extend it because there are no more implied assumptions like "each child
  class needs to set "$this->log" and "$this->table_prefix"