### PR TITLE
fix: #87

### DIFF
--- a/slackEvents.php
+++ b/slackEvents.php
@@ -234,12 +234,12 @@ class SlackEvents {
             $register = $parsed_event['is_registered'];
         } else {
             $user = $this->api->users_info($userid);
-            if(is_null($user)) {
+            $profile = $user->profile;
+            if(is_null($user) || !property_exists($profile, "email")) {
                 $this->log->error("Can't determine user mail from the Slack API");
                 exit(); // @TODO maybe throw something here
             }
-            $profile = $user->profile;
-            $this->log->debug("register from channel mail $profile->email $profile->first_name $profile->last_name");
+            $this->log->debug("register from channel mail $profile->email " . getUserNameFromSlackProfile($profile));
             if($register) {
                 $parsed_event["attendees"][] = $userid;
             } else {
@@ -286,7 +286,7 @@ class SlackEvents {
             $response = $this->agenda->updateAttendee($vCalendarFilename,
                                                       $profile->email,
                                                       $register,
-                                                      $profile->first_name . ' ' . $profile->last_name);
+                                                      getUserNameFromSlackProfile($profile));
         }
     }
     
@@ -330,12 +330,12 @@ class SlackEvents {
             exit(); // @TODO maybe throw something here
         }
         $profile = $user->profile;
-        $this->log->debug("register mail $profile->email $profile->first_name $profile->last_name");
+        $this->log->debug("register mail $profile->email " . getUserNameFromSlackProfile($profile));
         $parsed_event = $this->agenda->getParsedEvent($vCalendarFilename, $userid);
         slackEvents::ack();
         $this->register_fast_rendering($vCalendarFilename, $userid, $profile->email, $register, $request, $parsed_event);
         
-        $response = $this->agenda->updateAttendee($vCalendarFilename, $profile->email, $register, $profile->first_name . ' ' . $profile->last_name);
+        $response = $this->agenda->updateAttendee($vCalendarFilename, $profile->email, $register, getUserNameFromSlackProfile($profile));
 
         if(is_null($response)) { //nothing to do
             return;

--- a/slackEvents.php
+++ b/slackEvents.php
@@ -234,11 +234,11 @@ class SlackEvents {
             $register = $parsed_event['is_registered'];
         } else {
             $user = $this->api->users_info($userid);
-            $profile = $user->profile;
-            if(is_null($user) || !property_exists($profile, "email")) {
+            if(is_null($user) || !property_exists($user->profile, "email")) {
                 $this->log->error("Can't determine user mail from the Slack API");
                 exit(); // @TODO maybe throw something here
             }
+            $profile = $user->profile;
             $this->log->debug("register from channel mail $profile->email " . getUserNameFromSlackProfile($profile));
             if($register) {
                 $parsed_event["attendees"][] = $userid;

--- a/utils.php
+++ b/utils.php
@@ -239,3 +239,15 @@ function exception_handler($throwable) {
     $api->views_publish($data);
     exit();
 }
+
+# @see https://api.slack.com/methods/users.info
+function getUserNameFromSlackProfile($profile) {
+    if(property_exists($profile, "first_name") and property_exists($profile, "last_name")) {
+        return $profile->first_name . ' ' . $profile->last_name;
+    } else if(property_exists($profile, "real_name")) {
+        return $profile->real_name;
+    } else if(property_exists($profile, "display_name")) {
+        return $profile->display_name;
+    }
+    return "";
+}


### PR DESCRIPTION
From the Slack Documentation: https://api.slack.com/methods/users.info
`The profile hash contains as much information as the user has supplied in the default profile fields: first_name, last_name, real_name, display_name, skype, and the image_* fields. Only the image_* fields are guaranteed to be included.`