### PR TITLE
Don't die with 0 exit code

### DIFF
--- a/MySQLAgenda.php
+++ b/MySQLAgenda.php
@@ -24,7 +24,7 @@ class MySQLAgenda extends Agenda {
                            $this->password);
         } catch(Exception $e) {
             echo "Can't reach MySQL like database: ".$e->getMessage();
-            die();
+            die(1);
         }
     }
     

--- a/SqliteAgenda.php
+++ b/SqliteAgenda.php
@@ -20,7 +20,7 @@ class SqliteAgenda extends Agenda {
             return $pdo;
         } catch(Exception $e) {
             echo "Can't reach SQLite database: ".$e->getMessage();
-            die();
+            die(1);
         }
     }
     

--- a/agenda.php
+++ b/agenda.php
@@ -417,7 +417,7 @@ WHERE vCalendarFilename =:vCalendarFilename;");
         } catch (\PDOException $e) {
             $this->pdo->rollBack();
             $this->log->error($e->getMessage());
-            die($e->getMessage());
+            die(1);
         }
 
         if($new_event === false and $previous_datetime != $datetime_begin) {

--- a/tests/unitTests/AgendaTest.php
+++ b/tests/unitTests/AgendaTest.php
@@ -638,5 +638,10 @@ function mockSlackUser($slackId){
 }
 
 function getEnvOrDie(string $varname){
-    return getenv($varname) or die("Environment variable $varname should be defined");
+    $value = getenv($varname);
+    if ($value === false){
+        echo "Environment variable $varname should be defined\n";
+        die(1);
+    }
+    return $value;
 }


### PR DESCRIPTION
by default die() terminates the process with exit code 0, which is interpreted as
a success. It's annoying because consequently if a test run terminates on a die,
then the test runner will consider the test was successful (which is particularly
annoying in CI when all we care about is the exit code and we don't usually look
at the logs)

With this commit if we encounter error conditions which lead to die, the exit code
makes it clear that something bad occured