### PR TITLE
Speed up CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
     docker:
       # Specify the version you desire here
-      - image: circleci/php:8.0-node-browsers
+      - image: circleci/php:8.0
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
Our tests don't require a browser so we can use a simpler image. It's much faster to spawn it
so our CI runs are much faster with this change.