### PR TITLE
fix: string too long for the Slack API

### DIFF
--- a/slackEvents.php
+++ b/slackEvents.php
@@ -396,7 +396,7 @@ class SlackEvents {
             $options[] = [
                 "text"=> [
                     "type"  => "plain_text",
-                    "text"  => $vCalendar->VEVENT->DTSTART->getDateTime()->format('Y-m-d H:i:s') . " " .(string)$vCalendar->VEVENT->SUMMARY,
+                    "text"  => forceStringLength($vCalendar->VEVENT->DTSTART->getDateTime()->format('Y-m-d H:i:s') . " " .(string)$vCalendar->VEVENT->SUMMARY, 75),
                     "emoji" => true
                 ],
                 "value" => $vCalendarFilename

--- a/utils.php
+++ b/utils.php
@@ -251,3 +251,11 @@ function getUserNameFromSlackProfile($profile) {
     }
     return "";
 }
+
+function forceStringLength(string $str, int $max_length) {
+    if(strlen($str) > $max_length) {
+        return substr($str, 0, $max_length - 3) . "...";
+    } else {
+        return $str;
+    }
+}


### PR DESCRIPTION
prevent : `[ERROR] must be less than 76 characters` from the slack API

See: https://api.slack.com/reference/block-kit/block-elements
`A text object that defines the button's text. Can only be of type: plain_text. text may truncate with ~30 characters. Maximum length for the text in this field is 75 characters.`