### PR TITLE
Fix method visibility

### DIFF
--- a/agenda.php
+++ b/agenda.php
@@ -584,7 +584,7 @@ WHERE vCalendarFilename =:vCalendarFilename;");
         return true;
     }
     
-    private function addReminder(string $userid, string $vCalendarFilename, string $message, DateTimeImmutable $datetime) {
+    public function addReminder(string $userid, string $vCalendarFilename, string $message, DateTimeImmutable $datetime) {
         $now = new DateTimeImmutable();
         if ($datetime < $now){
             $this->log->debug("not creating the reminder for $userid because " . $datetime->format('Y-m-dTH:i:s') . " is in the past");


### PR DESCRIPTION
This visibility was reduced by edba60a342601662f02a3e4328b22aaf51664f04
but this method is called from slackEvent (I though I could pass it to private
because my git grep didn't find this method call because the case of the method
is different. I just learnt that PHP doesn't care about the case we use
when we call methods... :-/ )