### PR TITLE
All registrations may create a reminder

### DIFF
--- a/MySQLAgenda.php
+++ b/MySQLAgenda.php
@@ -9,12 +9,12 @@ class MySQLAgenda extends Agenda {
     private $username;
     private $password;
     
-    public function __construct(ICalDAVClient $caldav_client, object $api, array $agenda_args) {
+    public function __construct(ICalDAVClient $caldav_client, object $api, array $agenda_args, DateTimeImmutable $now) {
             $this->db_name = $agenda_args["db_name"];
             $this->host = $agenda_args["db_host"];
             $this->username = $agenda_args["db_username"];
             $this->password = $agenda_args["db_password"];
-            parent::__construct($agenda_args["db_table_prefix"], new Logger('MySQLAgenda'), $caldav_client, $api);
+            parent::__construct($agenda_args["db_table_prefix"], new Logger('MySQLAgenda'), $caldav_client, $api, $now);
         }
     
     protected function openDB() {

--- a/SqliteAgenda.php
+++ b/SqliteAgenda.php
@@ -8,9 +8,9 @@ use Sabre\VObject;
 class SqliteAgenda extends Agenda {
     private $path;
 
-    public function __construct(ICalDAVClient $caldav_client, object $api, array $agenda_args) {
+    public function __construct(ICalDAVClient $caldav_client, object $api, array $agenda_args, DateTimeImmutable $now) {
         $this->path = $agenda_args["path"];
-        parent::__construct($agenda_args["db_table_prefix"], new Logger('sqliteAgenda'), $caldav_client, $api);
+        parent::__construct($agenda_args["db_table_prefix"], new Logger('sqliteAgenda'), $caldav_client, $api, $now);
     }
     
     protected function openDB() {

--- a/agenda.php
+++ b/agenda.php
@@ -20,7 +20,10 @@ abstract class Agenda {
 
     protected $table_prefix;
 
-    public function __construct(string $table_prefix, Logger $log, ICalDAVClient $caldav_client, object $api) {
+    private DateTimeImmutable $now;
+    private DateTimeImmutable $beginningOfToday;
+
+    public function __construct(string $table_prefix, Logger $log, ICalDAVClient $caldav_client, object $api, DateTimeImmutable $now) {
         $this->table_prefix = $table_prefix;
         $this->log = $log;
         setLogHandlers($this->log);
@@ -32,6 +35,9 @@ abstract class Agenda {
         
         $this->pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION); // ERRMODE_WARNING | ERRMODE_EXCEPTION | ERRMODE_SILENT
+
+        $this->now = $now;
+        $this->beginningOfToday = $now->setTime(0, 0, 0, 0);
 
     }
     
@@ -92,11 +98,10 @@ abstract class Agenda {
     }
     
     /**
-     * @param $now The current time. Used to retrieve only the events not started yet
      * @param $userId The slack id of the current user. Used to compute on which events the user is registered
      * @param $filters_to_apply The filters that the returned events should match.
      */
-    public function getUserEventsFiltered(DateTimeImmutable $now, string $userid, array $filters_to_apply = array()) {
+    public function getUserEventsFiltered(string $userid, array $filters_to_apply = array()) {
         $sql = "SELECT event.vCalendarFilename, event.number_volunteers_required, event.vCalendarRaw FROM {$this->table_prefix}events event ";
 
         $my_events = false;
@@ -153,7 +158,7 @@ abstract class Agenda {
 
         $sql .= " ORDER BY event.datetime_begin;";
         $query = $this->pdo->prepare($sql);
-        $query->execute(array('datetime_begin' => $now->format('Y-m-d H:i:s')));
+        $query->execute(array('datetime_begin' => $this->beginningOfToday->format('Y-m-d H:i:s')));
         $results = $query->fetchAll(\PDO::FETCH_UNIQUE|\PDO::FETCH_ASSOC);
         
         foreach($results as $vCalendarFilename => &$result) {
@@ -190,11 +195,11 @@ abstract class Agenda {
         $result["categories"] = array_keys($categories);
     }
 
-    public function getEvents(DateTimeImmutable $now): array {
+    public function getEvents(): array {
         $query = $this->pdo->prepare("SELECT `vCalendarFilename`, `vCalendarRaw` 
                                       FROM {$this->table_prefix}events WHERE datetime_begin > :datetime_begin 
                                       ORDER BY datetime_begin;");
-        $query->execute(array('datetime_begin' => $now->format('Y-m-d H:i:s')));
+        $query->execute(array('datetime_begin' => $this->beginningOfToday->format('Y-m-d H:i:s')));
         $results = $query->fetchAll(\PDO::FETCH_UNIQUE|\PDO::FETCH_ASSOC);
         $events = array();
         foreach($results as $vCalendarFilename => $result) {
@@ -475,7 +480,7 @@ WHERE vCalendarFilename =:vCalendarFilename;");
         if (is_null($local_CTag) || $local_CTag != $remote_CTag){
             $this->log->debug("Agenda update needed");
             
-            $remote_ETags = $this->caldav_client->getETags(new DateTimeImmutable("today"));
+            $remote_ETags = $this->caldav_client->getETags($this->beginningOfToday);
             if($remote_CTag === false || is_null($remote_CTag)) {
                 $this->log->error("Fail to get CTag from the remote server");
                 return null;
@@ -596,12 +601,11 @@ WHERE vCalendarFilename =:vCalendarFilename;");
         return true;
     }
     
-    private function addReminder(string $userid, string $vCalendarFilename, string $message, DateTimeImmutable $datetime) {
-        $now = new DateTimeImmutable();
-        if ($datetime < $now){
-            $this->log->debug("not creating the reminder for $userid because " . $datetime->format('Y-m-dTH:i:s') . " is in the past");
+    private function addReminder(string $userid, string $vCalendarFilename, string $message, DateTimeImmutable $reminderTime) {
+        if ($reminderTime < $this->now){
+            $this->log->debug("not creating the reminder for $userid because " . $reminderTime->format('Y-m-dTH:i:s') . " is in the past");
         } else {
-            $response = $this->api->reminders_add($userid, "Rappel pour l'événement qui aura lieu dans 24h : $message", $datetime);
+            $response = $this->api->reminders_add($userid, "Rappel pour l'événement qui aura lieu dans 24h : $message", $reminderTime);
             $this->log->debug("Creating slack reminder: {$response->reminder->id} for event $vCalendarFilename");
             if(!is_null($response)) {
                 $this->log->debug("Adding reminder within the database.");
@@ -666,10 +670,11 @@ function initAgendaFromType(string $CalDAV_url, string $CalDAV_username, string 
     }
 
     $caldav_client = new CalDAVClient($CalDAV_url, $CalDAV_username, $CalDAV_password);
+    $now = new DateTimeImmutable();
     if($agenda_args["db_type"] === "MySQL") {
-        return new MySQLAgenda($caldav_client, $api, $agenda_args);
+        return new MySQLAgenda($caldav_client, $api, $agenda_args, $now);
     } else if($agenda_args["db_type"] === "sqlite") {
-        return new SqliteAgenda($caldav_client, $api, $agenda_args);
+        return new SqliteAgenda($caldav_client, $api, $agenda_args, $now);
     } else {
         $log->error("db type $agenda_args[db_type] is unknown (exit).");
         exit();

--- a/slackEvents.php
+++ b/slackEvents.php
@@ -286,7 +286,8 @@ class SlackEvents {
             $response = $this->agenda->updateAttendee($vCalendarFilename,
                                                       $profile->email,
                                                       $register,
-                                                      getUserNameFromSlackProfile($profile));
+                                                      getUserNameFromSlackProfile($profile),
+                                                      $userid);
         }
     }
     
@@ -335,7 +336,7 @@ class SlackEvents {
         slackEvents::ack();
         $this->register_fast_rendering($vCalendarFilename, $userid, $profile->email, $register, $request, $parsed_event);
         
-        $response = $this->agenda->updateAttendee($vCalendarFilename, $profile->email, $register, getUserNameFromSlackProfile($profile));
+        $response = $this->agenda->updateAttendee($vCalendarFilename, $profile->email, $register, getUserNameFromSlackProfile($profile), $userid);
 
         if(is_null($response)) { //nothing to do
             return;
@@ -344,19 +345,8 @@ class SlackEvents {
         if($response === false) {
             trigger_error("Event update failed", E_USER_ERROR); // it will: call error_handler, inform user and exit.
         }
-
-        $vCalendar = $parsed_event['vCalendar']->VEVENT;
-        $datetime = $vCalendar->DTSTART->getDateTime();
-        $datetime = $datetime->modify("-1 day");
-        
-        if($register) {
-            $summary = (string)$vCalendar->SUMMARY;
-            $this->agenda->AddReminder($userid, $vCalendarFilename, $summary, $datetime);
-        } else {
-            $this->agenda->DeleteReminder($userid, $vCalendarFilename);
-        }
     }
-    
+
     function filters_has_changed($action, $userid) {
         $filters_to_apply = array();
         foreach($action->selected_options as $filter) {

--- a/slackEvents.php
+++ b/slackEvents.php
@@ -47,7 +47,7 @@ class SlackEvents {
     function app_home_page($userid, $filters_to_apply = array()) {
         $this->log->info('event: app_home_opened received');
         
-        $events = $this->agenda->getUserEventsFiltered(new DateTimeImmutable('TODAY'), $userid, $filters_to_apply);
+        $events = $this->agenda->getUserEventsFiltered($userid, $filters_to_apply);
         
         $blocks = [];
         $default_filters = [
@@ -382,7 +382,7 @@ class SlackEvents {
 
     public function event_selection($channel_id, $trigger_id) {
         $options = [];
-        foreach($this->agenda->getEvents(new DateTimeImmutable('TODAY')) as $vCalendarFilename => $vCalendar) {
+        foreach($this->agenda->getEvents() as $vCalendarFilename => $vCalendar) {
             $options[] = [
                 "text"=> [
                     "type"  => "plain_text",

--- a/tests/unitTests/AgendaTest.php
+++ b/tests/unitTests/AgendaTest.php
@@ -426,7 +426,7 @@ final class AgendaTest extends TestCase {
 
         // Act & Assert
         // // Assert that the function considers it was successfully executed
-        $this->assertTrue($sut->updateAttendee($event->id(), "you@gmail.com", true, "Your Name"));
+        $this->assertTrue($sut->updateAttendee($event->id(), "you@gmail.com", true, "Your Name", "You"));
 
         // // Assert that the remote caldav server has been updated with correct parameters
         $this->assertEquals($event->id(), $caldav_client->updatedEvents[0][0]);
@@ -443,7 +443,7 @@ final class AgendaTest extends TestCase {
 
         // Act & Assert
         // // Assert that the function noticed that nothing was done
-        $this->isNull($sut->updateAttendee($event->id(), "you@gmail.com", true, "Your Name"));
+        $this->isNull($sut->updateAttendee($event->id(), "you@gmail.com", true, "Your Name", "You"));
 
         // // Assert that we did not try to update the caldav server
         $this->assertEquals(0, count($caldav_client->updatedEvents));
@@ -461,7 +461,7 @@ final class AgendaTest extends TestCase {
 
         // Act & Assert
         // // Assert that the function considers it was successfully executed
-        $this->assertTrue($sut->updateAttendee($event->id(), "you@gmail.com", false, "Your Name"));
+        $this->assertTrue($sut->updateAttendee($event->id(), "you@gmail.com", false, "Your Name", "You"));
 
         // // Assert that the remote caldav server has been updated with correct parameters
         $this->assertEquals($event->id(), $caldav_client->updatedEvents[0][0]);
@@ -478,7 +478,7 @@ final class AgendaTest extends TestCase {
 
         // Act & Assert
         // // Assert that the function noticed that nothing was done
-        $this->isNull($sut->updateAttendee($event->id(), "you@gmail.com", false, "Your Name"));
+        $this->isNull($sut->updateAttendee($event->id(), "you@gmail.com", false, "Your Name", "You"));
 
         // // Assert that we did not try to update the caldav server
         $this->assertEquals(0, count($caldav_client->updatedEvents));


### PR DESCRIPTION
This fixes #100.
The issue was that when a user register to an event which is displayed on
Slack after calling /remindEvent, then the registration is runs
`SlackEvents.more_inchannel` which doesn't call `Agenda.addReminder`.

This commit moves the creation of the reminder inside `Agenda.updateAttendee`
so every registration leads to the attempt to create a reminder.