### PR TITLE
fix #103

### DIFF
--- a/slack_app_manifest.yaml.sample
+++ b/slack_app_manifest.yaml.sample
@@ -6,7 +6,7 @@ display_information:
 features:
   app_home:
     home_tab_enabled: true
-    messages_tab_enabled: false
+    messages_tab_enabled: true
     messages_tab_read_only_enabled: true
   bot_user:
     display_name: AgendaZWP


### PR DESCRIPTION
- remove Slack reminders for deleted event;
- inform users that the event has been canceled;
- add test.