### PR TITLE
make it explicit that we require at least PHP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ How to install
 
 Prerequisites: you will need
 
-* A PHP web hosting (which has php-curl)
+* A PHP web hosting which runs PHP 8 (which has php-curl)
 * A slack space for your team (of course)
 * A CalDAV server (for instance you can use google calendar)
 * PHP Composer (you can get it from [here](https://getcomposer.org/))


### PR DESCRIPTION
We're using construct (in particular declaring the type of the field of classes) which does not seem compatible with php7