### PR TITLE
Limit the number of events returned

### DIFF
--- a/agenda.php
+++ b/agenda.php
@@ -225,7 +225,8 @@ abstract class Agenda {
     COUNT(distinct {$this->table_prefix}categories.id) = " . count($filters_to_apply);
         }
 
-        $sql .= " ORDER BY event.datetime_begin;";
+        $sql .= " ORDER BY event.datetime_begin";
+        $sql .= " LIMIT 0, 30;"; // We have to set a limit in the number of event because slack has a limit in the number of item we can return
         $query = $this->pdo->prepare($sql);
         $query->execute(array('datetime_begin' => $this->beginningOfToday->format('Y-m-d H:i:s')));
         $results = $query->fetchAll(\PDO::FETCH_UNIQUE|\PDO::FETCH_ASSOC);


### PR DESCRIPTION
Because slack has a limit on the number of items we can return.
It turns out that we reach this limit when we return more than 30
events.
Ideally we should add some pagination to adress this, but for now
a hard limit will avoid this issue.
(it will prevent users to see events farter in the future, but they
wouldn't be able to see it even without this limit since the app
would crash. At least with this patch they can still see the first events
and they can use category filters to see events farther in the future)