### PR TITLE
add scope chat:write.public

### DIFF
--- a/slack_app_manifest.yaml.sample
+++ b/slack_app_manifest.yaml.sample
@@ -28,6 +28,7 @@ oauth_config:
     bot:
       - commands
       - chat:write
+      - chat:write.public
       - users.profile:read
       - users:read.email
       - users:read


### PR DESCRIPTION
This should make it possible to use /remindEvent in any public channel without having
to invite the bot in the chan beforehand (it should still be needed to invite the bot in
private channels to use it there)