### PR TITLE
Fix bug in reminder creation

### DIFF
--- a/agenda.php
+++ b/agenda.php
@@ -696,7 +696,7 @@ WHERE vCalendarFilename =:vCalendarFilename;");
             if ($register) {
                 $eventStartDate = $vCalendar->VEVENT->DTSTART->getDateTime();
                 $reminderDate = $eventStartDate->modify("-1 day");
-                $summary = (string)$vCalendar->SUMMARY;
+                $summary = (string)$vCalendar->VEVENT->SUMMARY;
                 $this->addReminder($userid, $vCalendarFilename, $summary, $reminderDate);
             } else {
                 $this->deleteReminder($userid, $vCalendarFilename);


### PR DESCRIPTION
because of a mistake, the summary in the reminder was empty

It is a regression introduced by 16ae17abbc47adb985200e0412c4e12e80ec4bc9
(because the line
    (string)$vCalendar->SUMMARY;
was moved but in the 1st context we had $vCalendar which was set to
    $vCalendar = $parsed_event['vCalendar']->VEVENT;
whereas in the other it was not)