### PR TITLE
Don't log any error when we can't find a reminder to delete

### DIFF
--- a/slackAPI.php
+++ b/slackAPI.php
@@ -37,7 +37,8 @@ class SlackAPI implements ISlackAPI {
     protected $log;
 
     const QUIET_ERRORS = array(
-        "users_lookupByEmail" => array("users_not_found")
+        "users_lookupByEmail" => array("users_not_found"),
+        "reminders_delete" => array("not_found")
     );
     
     function __construct($slack_bot_token, $slack_user_token) {


### PR DESCRIPTION
as explained by the comment in the method agenda.php::deleteReminder
this is not an error. However we still logged it as any generic error
in SlackAPI.
This commit adds this error in the list of errors to ignore.