### PR TITLE
Be robust in case of non UTF-8 characters

### DIFF
--- a/slackAPI.php
+++ b/slackAPI.php
@@ -137,7 +137,7 @@ class SlackAPI implements ISlackAPI {
     function view_open($data, $trigger_id) {
         $ch = $this->curl_init("https://slack.com/api/views.open", array('application/x-www-form-urlencoded'));
         curl_setopt($ch, CURLOPT_POSTFIELDS, array(
-            "view" => json_encode($data),
+            "view" => json_encode($data, JSON_INVALID_UTF8_IGNORE),
             "trigger_id" => $trigger_id)
         );
         return $this->curl_process($ch);


### PR DESCRIPTION
Having non UTF-8 characters is a case we may encounter if a user creates an
event with a bad encoding. And by default json_encode returns "FALSE" if it
encounters non UTF-8 characters. In such case, the call to the slack API
subsequently fails because the payload is incorrect (it has "FALSE" instead
of an expected json payload).

Adding this flag seems to make is possible to cope correctly with such bad
input