### PR TITLE
Don't log a 412 as an error when it is expected

### DIFF
--- a/agenda.php
+++ b/agenda.php
@@ -697,14 +697,14 @@ WHERE vCalendarFilename =:vCalendarFilename;");
             }
         }
         
-        $new_ETag = $this->caldav_client->updateEvent($vCalendarFilename, $ETag, $vCalendar->serialize());
+        $new_ETag = $this->caldav_client->updateEvent($vCalendarFilename, $ETag, $vCalendar->serialize(), false);
         if($new_ETag === false) {
             // in case of error:  1. update the local agenda, 2. retry once.
             $this->log->warning("Fails to update the event, retrying");
             $this->checkAgenda();
             $ETag = $this->getEvent($vCalendarFilename)[1]; // retrieve the new ETag (if the event has been updated)
             $this->log->warning("Retrying...");
-            $new_ETag = $this->caldav_client->updateEvent($vCalendarFilename, $ETag, $vCalendar->serialize());
+            $new_ETag = $this->caldav_client->updateEvent($vCalendarFilename, $ETag, $vCalendar->serialize(), true);
             if($new_ETag === false) {
                 $this->log->error("Fails to update the event");
                 return false; // the event has not been updated

--- a/tests/unitTests/MockCalDAVClient.php
+++ b/tests/unitTests/MockCalDAVClient.php
@@ -43,7 +43,7 @@ class MockCalDAVClient implements ICalDAVClient {
     }
 
 
-    public function updateEvent($vCalendarFilename, $ETag, $vCalendarRaw) {
+    public function updateEvent($vCalendarFilename, $ETag, $vCalendarRaw, bool $log412AsError) {
         // To keep the mock simple we don't bother trying to update $this->events (we don't need it in tests anyway)
         
         if(!$this->returnETagAfterUpdate) {


### PR DESCRIPTION
Since the caldav server may be edited concurrently by several clients,
it is expected that we may get a 412 when we first try to update an event
(and we handle this case with a retry after a re-sync).
In this case it is pointless to log an error because we don't need to worry
about it.
With this patch such situation is now logged as an info.

This fixes #141