### PR TITLE
Ensure events are not displayed as html

### DIFF
--- a/slackEvents.php
+++ b/slackEvents.php
@@ -86,7 +86,7 @@ class SlackEvents {
         }
         
         if($description) {
-            $infos .= PHP_EOL . PHP_EOL . '*Description:*' . PHP_EOL . PHP_EOL . forceStringLength($parsed_event["vCalendar"]->VEVENT->DESCRIPTION, 2500);
+            $infos .= PHP_EOL . PHP_EOL . '*Description:*' . PHP_EOL . PHP_EOL . forceStringLength(toRawText($parsed_event["vCalendar"]->VEVENT->DESCRIPTION), 2500);
         }
 
         $block = [

--- a/tests/unitTests/utilsTest.php
+++ b/tests/unitTests/utilsTest.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+require_once "../utils.php";
+
+use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertEquals;
+
+final class utilsTest extends TestCase {
+  public function test_toRawText() {
+    assertEquals("html text", toRawText("<body><b>html</b> text</body>"));
+    assertEquals("text already raw", toRawText("text already raw"));
+    assertEquals("text with self-closing tag", toRawText("text with <br />self-closing tag"));
+  }
+}

--- a/utils.php
+++ b/utils.php
@@ -272,3 +272,7 @@ function forceStringLength(string $str, int $max_length) {
         return $str;
     }
 }
+
+function toRawText($potentiallyHtmlText) {
+  return strip_tags($potentiallyHtmlText);
+}


### PR DESCRIPTION
otherwise Slack displays the tags, which results
in a poor user experience