### PR TITLE
Refacto exception

### DIFF
--- a/inc/agenda.php
+++ b/inc/agenda.php
@@ -581,7 +581,8 @@ WHERE vCalendarFilename =:vCalendarFilename;");
      * @param string $vCalendarFilename the id of the event to parse
      * @param string $userid The slack id of the user (used to know if (s)he is registered to the event
      *
-     * @return either the parsed event if it was found, or false (it means that the event was deleted or that it is in the past)
+     * @return The parsed event if it was found
+     * @throws EventNotFound if the event was deleted or is in the past
      */
     public function getParsedEvent(string $vCalendarFilename, string $userid) {
         $sql = "SELECT vCalendarFilename, number_volunteers_required, vCalendarRaw FROM {$this->table_prefix}events WHERE vCalendarFilename = :vCalendarFilename";
@@ -591,7 +592,7 @@ WHERE vCalendarFilename =:vCalendarFilename;");
         ));
         $result = $query->fetch(\PDO::FETCH_UNIQUE|\PDO::FETCH_ASSOC);
         if ($result === false) { // Case of an event deleted or in the past
-            return false;
+            throw new EventNotFound();
         }
 
         $this->parseEvent($result['vCalendarFilename'], $userid, $result);

--- a/inc/agenda.php
+++ b/inc/agenda.php
@@ -604,7 +604,7 @@ WHERE vCalendarFilename =:vCalendarFilename;");
         $result = $query->fetchAll();
 
         if(count($result) === 0) {
-            return null;
+          throw new EventNotFound();
         }
 
         return [\Sabre\VObject\Reader::read($result[0]['vCalendarRaw']), $result[0]['ETag']];
@@ -703,9 +703,6 @@ WHERE vCalendarFilename =:vCalendarFilename;");
             $this->log->warning("Fails to update the event, retrying");
             $this->checkAgenda();
             $event = $this->getEvent($vCalendarFilename);
-            if(is_null($event)) {
-                throw new EventNotFound();
-            }
             $ETag = $event[1]; // retrieve the new ETag (if the event has been updated)
             $this->log->warning("Retrying...");
             $new_ETag = $this->caldav_client->updateEvent($vCalendarFilename, $ETag, $vCalendar->serialize(), true);

--- a/inc/slackEvents.php
+++ b/inc/slackEvents.php
@@ -356,28 +356,20 @@ class SlackEvents {
                 header("Content-type:application/json");
                 echo json_encode($response);
                 fastcgi_finish_request();
-                try {
-                    $response = $this->agenda->updateAttendee($vCalendarFilename,
-                                                              $profile->email,
-                                                              $register,
-                                                              getUserNameFromSlackProfile($profile),
-                                                              $userid);
-                } catch (EventNotFound $e) {
-                    trigger_error("L'événement: " .
-                                  (string)$parsed_event["vCalendar"]->VEVENT->SUMMARY .
-                                  " du " .
-                                  strftime("%A %d %B %Y", $parsed_event["vCalendar"]->VEVENT->DTSTART->getDateTime()->getTimestamp()) .
-                                  " n'existe pas.");
-                } catch (EventUpdateFails $e) {
-                    trigger_error("L'événement: " .
-                                  (string)$parsed_event["vCalendar"]->VEVENT->SUMMARY .
-                                  " du " .
-                                  strftime("%A %d %B %Y", $parsed_event["vCalendar"]->VEVENT->DTSTART->getDateTime()->getTimestamp()) .
-                                  " n'a pas pu être modifié.");
-                }
+                $response = $this->agenda->updateAttendee($vCalendarFilename,
+                                                          $profile->email,
+                                                          $register,
+                                                          getUserNameFromSlackProfile($profile),
+                                                          $userid);
             }
         } catch (EventNotFound $e) {
           $data = $this->postViewOpenForUnfindableEvent($trigger_id);
+        } catch (EventUpdateFails $e) {
+            trigger_error("L'événement: " .
+                          (string)$parsed_event["vCalendar"]->VEVENT->SUMMARY .
+                          " du " .
+                          strftime("%A %d %B %Y", $parsed_event["vCalendar"]->VEVENT->DTSTART->getDateTime()->getTimestamp()) .
+                          " n'a pas pu être modifié.");
         }
     }
     

--- a/tests/unitTests/AgendaTest.php
+++ b/tests/unitTests/AgendaTest.php
@@ -507,7 +507,8 @@ final class AgendaTest extends TestCase {
         $sut->checkAgenda();
 
         // Act & Assert
-        $this->assertFalse($sut->getParsedEvent("some_event_id", "MYID"));
+        $this->expectException(EventNotFound::class);
+        $sut->getParsedEvent("some_event_id", "MYID");
     }
 
     public function returnETagAfterUpdateProvider() {


### PR DESCRIPTION
(note that this PR is built on top of #155 so it would be more convenient to review that other one before. This current PR only has 2 commits on its own)

This PR changes a bit the way we manipulate exceptions. In a nutshell it:
- favor throwing instead of returning NULL or FALSE in case of event not found (hence making the code more consistent)
- simplifies a bit the code because now `Agenda::getParsedEvent` can only return an event (instead of "an event OR a boolean") which may make it possible to propose a future refacto I have in mind)