### PR TITLE
Fix clitools

### DIFF
--- a/clitools
+++ b/clitools
@@ -19,11 +19,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 
-require __DIR__ . '/vendor/autoload.php';
-require "slackAPI.php";
-require "utils.php";
-require "agenda.php";
-require_once "CalDAVClient.php";
+require_once __DIR__ . '/vendor/autoload.php';
+require_once "inc/slackAPI.php";
+require_once "inc/utils.php";
+require_once "inc/agenda.php";
+require_once "inc/CalDAVClient.php";
 
 $log = new Logger('CLITOOLS');
 $log->pushHandler(new StreamHandler('php://stdout', Logger::DEBUG));

--- a/tests/unitTests/clitoolsTest.php
+++ b/tests/unitTests/clitoolsTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+
+use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertEquals;
+
+final class ClitoolsTest extends TestCase {
+
+  /**
+   * The point of this test is just to ensure clitools is not obviously broken
+   * (eg: making sure we did not mess with the path of the "require" statements)
+   */
+  public function test_canInvokeCliTools() {
+    $exitCode = 0;
+    $placeholder = array();
+    exec("../clitools help", $placeholder, $exitCode);
+
+    $this->assertEquals($exitCode, 0);
+  }
+}


### PR DESCRIPTION
it was broken because the "require"d paths have not been adapted when I moved the files.
(in the process I replaced "require" by "require_once" so we won't
 have to bother making sure we don't have double-require at any point)

This commit also adds a test to ensure this kind of bug cannot go unoticed again.