### PR TITLE
Rm user token

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ Create the Slack app
 
 To create your app please follow [this page](https://api.slack.com/apps), then click `Create New App` and choose `from an app manifest file`. Copy/paste the content of the file `slack_app_manifest.yaml.sample`, after having configured it (especially the fields: `name`, `display_name` and `request_url`). `request_url` must reach the file `index.php` on your HTTP server.
 
-TODO (in particular, mention that a dedicated user should be created for the reminders)
-
 Installing the PHP scripts
 --------------------------
 Get the code:

--- a/actions.php
+++ b/actions.php
@@ -32,7 +32,7 @@ $json = json_decode($_POST['payload']);
 
 $GLOBALS['userid'] = $json->user->id; // in case we need to show an error message to the user
 
-$api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
+$api = new SlackAPI($slack_credentials['bot_token']);
 $agenda = initAgendaFromType($caldav_credentials['url'], $caldav_credentials['username'], $caldav_credentials['password'],
                              $api, $agenda_args, $log);
 $slack_events = new SlackEvents($agenda, $api, $log);

--- a/clitools
+++ b/clitools
@@ -38,8 +38,8 @@ class RemindersLister extends Command {
     public function run() {
         global $log;
         list($slack_credentials, $caldav_credentials, $agenda_args) = read_config_file();
-        $api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
-        $user_infos = $api->auth_test("user");
+        $api = new SlackAPI($slack_credentials['bot_token']);
+        $user_infos = $api->auth_test();
         foreach($api->listScheduledMessages() as $id => $reminder) {
             $log->info("Reminder:");
             foreach($reminder as $key => $val) {
@@ -61,8 +61,8 @@ class RemindersPurger extends Command {
     public function run() {
         global $log;
         list($slack_credentials, $caldav_credentials, $agenda_args) = read_config_file();
-        $api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
-        $user_infos = $api->auth_test("user");
+        $api = new SlackAPI($slack_credentials['bot_token']);
+        $user_infos = $api->auth_test();
         foreach($api->listScheduledMessages() as $id => $reminder) {
             $log->info("deleting reminder id: $reminder[id]\n");
             $api->deleteScheduledMessage($reminder["channel_id"], $reminder["id"]);
@@ -325,24 +325,12 @@ function config_read() {
 function api_checktokens() {
     global $log;
     list($slack_credentials, $caldav_credentials, $agenda_args) = read_config_file();
-    $api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
+    $api = new SlackAPI($slack_credentials['bot_token']);
 
     $ok = true;
-    $log->info("Checking Slack user token...");
-    $ret = $api->auth_test("user");
-    if(!is_null($ret) && $ret->ok) {
-        if(!isset($ret->bot_id)) {
-            $log->info("Checking Slack user token - ok.");
-        } else {
-            $log->info("Checking Slack user token - nok (bot token instead)");
-        }
-    } else {
-        $ok = false;
-        $log->info("Checking Slack user token - nok.");
-    }
 
     $log->info("Checking Slack bot token...");
-    $ret = $api->auth_test("bot");
+    $ret = $api->auth_test();
     if(!is_null($ret) && $ret->ok) {
         if(isset($ret->bot_id)) {
             $log->info("Checking Slack bot token - ok.");
@@ -374,7 +362,7 @@ function caldavclient_checkauth() {
 function open_agenda() {
     global $log;
     list($slack_credentials, $caldav_credentials, $agenda_args) = read_config_file();
-    $api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
+    $api = new SlackAPI($slack_credentials['bot_token']);
     
     $agenda = initAgendaFromType($caldav_credentials['url'], $caldav_credentials['username'], $caldav_credentials['password'],
                                  $api, $agenda_args, $log);

--- a/clitools
+++ b/clitools
@@ -40,15 +40,13 @@ class RemindersLister extends Command {
         list($slack_credentials, $caldav_credentials, $agenda_args) = read_config_file();
         $api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
         $user_infos = $api->auth_test("user");
-        foreach($api->reminders_list() as $id => $reminder) {
-            if($user_infos->user_id === $reminder["creator"]) { // list only reminders that have been created by the app
-                $log->info("Reminder:");
-                foreach($reminder as $key => $val) {
-                    if(is_null($val)) {
-                        $log->info("    $key = null");
-                    } else {
-                        $log->info("    $key = $val");
-                    }
+        foreach($api->listScheduledMessages() as $id => $reminder) {
+            $log->info("Reminder:");
+            foreach($reminder as $key => $val) {
+                if(is_null($val)) {
+                    $log->info("    $key = null");
+                } else {
+                    $log->info("    $key = $val");
                 }
             }
         }
@@ -65,11 +63,9 @@ class RemindersPurger extends Command {
         list($slack_credentials, $caldav_credentials, $agenda_args) = read_config_file();
         $api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
         $user_infos = $api->auth_test("user");
-        foreach($api->reminders_list() as $id => $reminder) {
-            if($user_infos->user_id === $reminder["creator"]) { // delete only reminders that have been created by the app
-                $log->info("deleting reminder id: $reminder[id]\n");
-                $api->reminders_delete($reminder["id"]);
-            }
+        foreach($api->listScheduledMessages() as $id => $reminder) {
+            $log->info("deleting reminder id: $reminder[id]\n");
+            $api->deleteScheduledMessage($reminder["channel_id"], $reminder["id"]);
         }
     }
 

--- a/commands.php
+++ b/commands.php
@@ -29,7 +29,7 @@ if(!isset($_POST['command'])) {
 }
 $command = $_POST['command'];
 
-$api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
+$api = new SlackAPI($slack_credentials['bot_token']);
 $agenda = initAgendaFromType($caldav_credentials['url'], $caldav_credentials['username'], $caldav_credentials['password'],
                              $api, $agenda_args, $log);
 $slack_events = new SlackEvents($agenda, $api, $log);

--- a/config.json.sample
+++ b/config.json.sample
@@ -1,6 +1,5 @@
 {
     "slack_signing_secret" : "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    "slack_user_token" : "xoxp-xxxxxxxxxxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "slack_bot_token" : "xoxb-xxxxxxxxxxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx",
     "caldav_username" : "user@server.com",
     "caldav_password" : "xxxxxxxxxxxxxxxx",

--- a/events.php
+++ b/events.php
@@ -29,7 +29,7 @@ if(!property_exists($json, 'event') || !property_exists($json->event, 'type')) {
     exit();
 }
 
-$api = new SlackAPI($slack_credentials['bot_token'], $slack_credentials['user_token']);
+$api = new SlackAPI($slack_credentials['bot_token']);
 $agenda = initAgendaFromType($caldav_credentials['url'], $caldav_credentials['username'], $caldav_credentials['password'],
                              $api, $agenda_args, $log);
 $slack_events = new SlackEvents($agenda, $api, $log);

--- a/inc/slackEvents.php
+++ b/inc/slackEvents.php
@@ -473,7 +473,7 @@ class SlackEvents {
 
     public function event_selection($channel_id, $trigger_id) {
         // check if the app is integrated in the channel
-        $app_infos = $this->api->auth_test("bot");
+        $app_infos = $this->api->auth_test();
         $app_id = $app_infos->user_id;
         $members = $this->api->conversations_members($channel_id);
 

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -55,16 +55,14 @@ function read_config_file() {
     $GLOBALS['LOG_HANDLERS'][] = $handler;
     
     if(!isset($config['slack_signing_secret']) ||
-       !isset($config['slack_bot_token']) ||
-       !isset($config['slack_user_token'])) {
+       !isset($config['slack_bot_token'])) {
         $log->error("Slack signing secret and/or tokens not stored in config.json (exit).");
         exit();
     }
 
     $slack_credentials = array(
         "signing_secret" => $config['slack_signing_secret'],
-        "bot_token" => $config['slack_bot_token'],
-        "user_token" => $config['slack_user_token'],
+        "bot_token" => $config['slack_bot_token']
     );
     
     if(
@@ -247,7 +245,7 @@ function exception_handler($throwable) {
         exit();
     }
     
-    $api = new SlackAPI($config->slack_bot_token, $config->slack_user_token);
+    $api = new SlackAPI($config->slack_bot_token);
 
     $api->chat_postMessage($GLOBALS['userid'], array([
         'type' => 'section',

--- a/slack_app_manifest.yaml.sample
+++ b/slack_app_manifest.yaml.sample
@@ -23,8 +23,6 @@ oauth_config:
       - users:read.email
       - users.profile:read
       - identify
-      - reminders:write
-      - reminders:read
     bot:
       - commands
       - chat:write

--- a/tests/unitTests/AgendaTest.php
+++ b/tests/unitTests/AgendaTest.php
@@ -393,7 +393,7 @@ final class AgendaTest extends TestCase {
         // Setup
         $event = new MockEvent(array(), array());
         $caldav_client = $this->buildCalDAVClient(array($event), true);
-        $this->slackApiMock->method('reminders_add')->willReturn(json_decode('{"reminder": {"id": "abc"}}'));
+        $this->slackApiMock->method('scheduleMessage')->willReturn(json_decode('{"scheduled_message_id":"Q0532DC44F4"}'));
 
         $sut = AgendaTest::buildSUT($caldav_client);
         $sut->checkAgenda();
@@ -405,8 +405,8 @@ final class AgendaTest extends TestCase {
         // Now we delete the event from the caldav server
         $caldav_client->setNewEvents(array());
         
-        // expect calls to reminders_delete (to remove the Slack reminder) and to chat_postMessage (to inform the user)
-        $this->slackApiMock->expects($this->once())->method('reminders_delete');
+        // expect calls to deleteScheduledMessage (to remove the Slack reminder) and to chat_postMessage (to inform the user)
+        $this->slackApiMock->expects($this->once())->method('deleteScheduledMessage');
         $this->slackApiMock->expects($this->once())->method('chat_postMessage');        
 
         // Assert
@@ -525,11 +525,11 @@ final class AgendaTest extends TestCase {
         // // Assert we will query the slack api to register the reminder
         $this->slackApiMock->
             expects($this->once())->
-            method('reminders_add')->
+            method('scheduleMessage')->
             with("You",
                  "Rappel pour l'événement qui aura lieu dans 24h : Nom de l'événement",
                  $event->getSabreObject()->VEVENT->DTSTART->getDateTime()->modify("-1 day"))->
-            willReturn(json_decode('{"reminder": {"id": "abc"}}'));
+            willReturn(json_decode('{"scheduled_message_id":"Q0532DC44F4"}'));
         $sut = AgendaTest::buildSUT($caldav_client);
         $sut->checkAgenda();
 
@@ -548,7 +548,7 @@ final class AgendaTest extends TestCase {
         $event = new MockEvent(array(), array("you@gmail.com"));
         $caldav_client = $this->buildCalDAVClient(array($event));
         // // Assert we will NOT query the slack api to register the reminder
-        $this->slackApiMock->expects($this->never())->method('reminders_add');
+        $this->slackApiMock->expects($this->never())->method('scheduleMessage');
         $sut = AgendaTest::buildSUT($caldav_client);
         $sut->checkAgenda();
 
@@ -569,9 +569,9 @@ final class AgendaTest extends TestCase {
         // // this ensures that the database will be in a consistent state when we act
         $event = new MockEvent();
         $caldav_client = $this->buildCalDAVClient(array($event), $returnETagAfterUpdate);
-        $this->slackApiMock->method('reminders_add')->willReturn(json_decode('{"reminder": {"id": "abc"}}'));
+        $this->slackApiMock->method('scheduleMessage')->willReturn(json_decode('{"scheduled_message_id":"Q0532DC44F4"}'));
         // // Assert we will query the slack api to delete the reminder
-        $this->slackApiMock->expects($this->once())->method('reminders_delete');
+        $this->slackApiMock->expects($this->once())->method('deleteScheduledMessage');
         $sut = AgendaTest::buildSUT($caldav_client);
         $sut->checkAgenda();
         $sut->updateAttendee($event->id(), "you@gmail.com", true, "Your Name", "You");
@@ -595,7 +595,7 @@ final class AgendaTest extends TestCase {
         $event = new MockEvent();
         $caldav_client = $this->buildCalDAVClient(array($event));
         // // Assert we will not query the slack api to delete a reminder
-        $this->slackApiMock->expects($this->never())->method('reminders_delete');
+        $this->slackApiMock->expects($this->never())->method('deleteScheduledMessage');
         $sut = AgendaTest::buildSUT($caldav_client);
         $sut->checkAgenda();
 


### PR DESCRIPTION
It was only needed to create reminders, so we don't need it anymore.
Removing it simplifies a bit our code and the conf.

(Note that this PR is based on top of PR 168, which should be merged before looking at that one.)