### PR TITLE
Add some log in order identify our bottlenecks

### DIFF
--- a/inc/agenda.php
+++ b/inc/agenda.php
@@ -590,7 +590,9 @@ WHERE vCalendarFilename =:vCalendarFilename;");
         $query->execute(array(
             'vCalendarFilename' => $vCalendarFilename
         ));
+        $this->log->debug("Going to getParsedEvent from db");
         $result = $query->fetch(\PDO::FETCH_UNIQUE|\PDO::FETCH_ASSOC);
+        $this->log->debug("Done getting getParsedEvent from db");
         if ($result === false) { // Case of an event deleted or in the past
             throw new EventNotFound();
         }
@@ -601,8 +603,10 @@ WHERE vCalendarFilename =:vCalendarFilename;");
         
     private function getEvent(string $vCalendarFilename) {
         $query = $this->pdo->prepare("SELECT * FROM {$this->table_prefix}events WHERE vCalendarFilename = :vCalendarFilename");
+        $this->log->debug("Going to getEvent from db");
         $query->execute(array('vCalendarFilename' => $vCalendarFilename));
         $result = $query->fetchAll();
+        $this->log->debug("Done getting getEvent from db");
 
         if(count($result) === 0) {
           throw new EventNotFound();
@@ -612,7 +616,9 @@ WHERE vCalendarFilename =:vCalendarFilename;");
     }
 
     public function checkAgenda() {
+        $this->log->debug("Going to get remote CTag");
         $remote_CTag = $this->caldav_client->getCTag();
+        $this->log->debug("Got remote CTag");
         if(is_null($remote_CTag)) {
             $this->log->error("Fail to update the CTag");
             return null;
@@ -765,7 +771,8 @@ WHERE vCalendarFilename =:vCalendarFilename;");
                     'id' => $response->scheduled_message_id,
                     'vCalendarFilename' =>  $vCalendarFilename,
                     'userid' =>  $userid
-                ));                
+                ));
+                $this->log->debug("Done adding the reminder in database");
             } else {
                 $this->log->error("failed to create reminder");
             }

--- a/inc/slackAPI.php
+++ b/inc/slackAPI.php
@@ -60,7 +60,9 @@ class SlackAPI implements ISlackAPI {
     }
 
     protected function curl_process($ch, $as_array=false) {
+        $this->log->debug("Going to perform a curl query");
         $response = curl_exec($ch);
+        $this->log->debug("Completed the curl query");
         curl_close($ch);
         $json = json_decode($response, $as_array);
         


### PR DESCRIPTION
It's not so rare that a query takes at least 1s to be handled. It's rather slow in itself, and it may be an issue since Slack has a 3s timeout (that we may fail to respect some times).

There may be ways to speed up our code (eg: caching on the filesystem some complex sql queries for which we would have the certainty that the data would remain up to date).

This commit adds some logs, and since each log it dumped with a timestamp, this should make it easier to understand where the time is going and hence where it could make sense to think of some caching system (and subsequently, if we end up developing some optimizations, it could help checking that said optimizations would actually save time)