### PR TITLE
Improve a bit CircleCI conf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,6 @@ jobs:
 
 workflows:
   version: 2
-  build-deploy:
+  build:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,15 +19,12 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            # "composer.lock" can be used if it is committed to the repo
-            - v1-dependencies-{{ checksum "composer.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v1-dependencies-{{ checksum "composer.lock" }}
 
       - run: composer install -n --prefer-dist
 
       - save_cache:
-          key: v1-dependencies-{{ checksum "composer.json" }}
+          key: v1-dependencies-{{ checksum "composer.lock" }}
           paths:
             - ./vendor
 


### PR DESCRIPTION
it was left like the default conf because I did not understood it clearly back then. Now that I understand that it's actually pretty simple I simplify it.
In particular this commit:
- leverages composer.lock to compute the cache key (because we have it in our repo and it's more accurate than composer.json)
- removes the cache fallback as it would never make sense to use it in our case