### PR TITLE
Fix PHP8.2 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/php:8.0 # The primary container where steps are run
+      - image: cimg/php:8.2 # The primary container where steps are run
       - image: cimg/mysql:8.0
         environment:
           MYSQL_ROOT_PASSWORD: rootpw

--- a/inc/CalDAVClient.php
+++ b/inc/CalDAVClient.php
@@ -69,6 +69,8 @@ class CalDAVClient implements ICalDAVClient {
     private $url;
     private $username;
     private $password;
+
+    private $log;
     
     public function __construct($url, $username, $password) {
         $this->log = new Logger('CalDAVClient');

--- a/inc/agenda.php
+++ b/inc/agenda.php
@@ -35,6 +35,7 @@ abstract class Agenda {
     protected $caldav_client;
     protected $api;
     protected $pdo;
+    protected $log;
 
     protected $table_prefix;
 

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,18 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    colors="true"
-    stderr="true"
-    convertDeprecationsToExceptions="true"
-    >
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">../</directory>
-            <exclude>
-                <directory suffix=".php">../vendor/</directory>
-                <directory suffix=".php">../tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" stderr="true" convertDeprecationsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">../</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">../vendor/</directory>
+      <directory suffix=".php">../tests/</directory>
+    </exclude>
+  </coverage>
 </phpunit>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -2,6 +2,7 @@
 <phpunit
     colors="true"
     stderr="true"
+    convertDeprecationsToExceptions="true"
     >
 
     <filter>

--- a/tests/unitTests/MockEvent.php
+++ b/tests/unitTests/MockEvent.php
@@ -6,7 +6,13 @@ require_once "testUtils.php";
 class MockEvent {
     // We don't care the actual etag of a mock event, they just need to be unique, so we keep a
     // counter that we increment
-    private static $lastEventEtag = 0;
+    private static int $lastEventEtag = 0;
+
+    private string $name;
+    private string $dtstart;
+    private array $categories;
+    private array $attendeesEmail;
+    private string $etag;
 
     public function __construct(array $categories = array(), array $attendeesEmail = array(), $name = ""){
         $this->name = $name === "" ? self::generateUniqName() : $name;

--- a/tests/unitTests/clitoolsTest.php
+++ b/tests/unitTests/clitoolsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use function PHPUnit\Framework\assertEquals;
 
-final class ClitoolsTest extends TestCase {
+final class clitoolsTest extends TestCase {
 
   /**
    * The point of this test is just to ensure clitools is not obviously broken


### PR DESCRIPTION
As explained on https://php.watch/versions/8.2/dynamic-properties-deprecated it is now deprecated to reference a class field which is not explicitely declared.
This PR fix this PHP8.2 incompatibility (it's the only incompatibility I'm aware of, so I guess we could migrate our prod to PHP8.2 once this is merged)